### PR TITLE
`StateMachine` can find event that can be applied given the current state, even if multiple events with the same name exist + some other changes.

### DIFF
--- a/Sources/StateMachine.swift
+++ b/Sources/StateMachine.swift
@@ -66,7 +66,7 @@ open class StateMachine<T:Hashable> {
     open private(set) var currentState : State<T>
     
     /// Available states in state machine
-    private lazy var availableStates : [State<T>] = []
+    public private(set) lazy var availableStates : [State<T>] = []
     
     /// Available events in state machine
     private lazy var events : [Event<T>] = []
@@ -77,7 +77,7 @@ open class StateMachine<T:Hashable> {
     {
         self.initialState = initialState
         self.currentState = initialState
-        availableStates.append(initialState)
+        addState(initialState)
     }
     
     /// Create `StateMachine` with initialState value
@@ -94,7 +94,7 @@ open class StateMachine<T:Hashable> {
     convenience public init(initialState: State<T>, states: [State<T>])
     {
         self.init(initialState: initialState)
-        self.availableStates.append(contentsOf: states)
+        addStates(states)
     }
     
     /// Activate state, if it's present in `StateMachine`. This method is not tied to events, present in StateMachine.
@@ -131,13 +131,14 @@ open class StateMachine<T:Hashable> {
     /// Add state to array of available states
     /// - Parameter state: state to add
     open func addState(_ state: State<T>) {
-        availableStates.append(state)
+        addStates([state])
     }
     
     /// Add array of states
     /// - Parameter states: states array.
     open func addStates(_ states: [State<T>]) {
-        availableStates.append(contentsOf: states)
+        let availableStateNames = Set(availableStates.map { $0.value })
+        availableStates.append(contentsOf: states.filter { !availableStateNames.contains($0.value) })
     }
     
     /// Add event to `StateMachine`. This method checks, whether source states and destination state of event are present in `StateMachine`. If not - event will not be added, and this method will throw.

--- a/Sources/StateMachine.swift
+++ b/Sources/StateMachine.swift
@@ -219,11 +219,10 @@ open class StateMachine<T:Hashable> {
      - Returns: true, if event can be fired, false if don't
     */
     open func canFireEvent(_ eventName: String) -> Bool {
-        if let event = eventWithName(eventName)
-        {
-           return canFireEvent(event)
+        let events = eventsWithName(eventName)
+        return events.contains { (event) -> Bool in
+            return canFireEvent(event)
         }
-        return false
     }
     
     /**
@@ -256,10 +255,10 @@ open class StateMachine<T:Hashable> {
     /// Retrieve event with specific name
     /// - Parameter name: Name of the event
     /// - Returns: event, if found.
-    open func eventWithName(_ name: String) -> Event<T>? {
+    open func eventsWithName(_ name: String) -> [Event<T>] {
         return events.filter { (element) -> Bool in
             return element.name == name
-        }.first
+        }
     }
     
     /// Check, whether state machine is in concrete state
@@ -285,7 +284,10 @@ private extension StateMachine {
      */
     ///
     func _fireEventNamed(_ eventName: String) -> Transition<T> {
-        if let event = eventWithName(eventName) {
+        let events = eventsWithName(eventName)
+        guard !events.isEmpty else { return .error(.unknownEvent) }
+
+        for event in events {
             let possibleTransition = possibleTransitionForEvent(event)
             switch possibleTransition {
             case .success(let sourceState, let destinationState):
@@ -307,12 +309,11 @@ private extension StateMachine {
                 else {
                     return processState()
                 }
-            default :
-                return possibleTransition
+            default:
+                break
             }
         }
-        else {
-            return .error(.unknownEvent)
-        }
+
+        return .error(.wrongSourceState)
     }
 }

--- a/Sources/StateMachine.swift
+++ b/Sources/StateMachine.swift
@@ -289,23 +289,23 @@ private extension StateMachine {
             let possibleTransition = possibleTransitionForEvent(event)
             switch possibleTransition {
             case .success(let sourceState, let destinationState):
+                let processState = { () -> Transition<T> in
+                    event.willFireEvent?(event)
+                    self.activateState(event.destinationValue)
+                    event.didFireEvent?(event)
+                    return .success(sourceState: sourceState, destinationState: destinationState)
+                }
+
                 if let shouldBlock = event.shouldFireEvent {
                     if shouldBlock(event) {
-                        event.willFireEvent?(event)
-                        activateState(event.destinationValue)
-                        event.didFireEvent?(event)
-                        return .success(sourceState: sourceState, destinationState: destinationState)
+                        return processState()
                     }
                     else {
                         return .error(.transitionDeclined)
                     }
                 }
                 else {
-                    let sourceState = self.currentState
-                    event.willFireEvent?(event)
-                    activateState(event.destinationValue)
-                    event.didFireEvent?(event)
-                    return .success(sourceState: sourceState, destinationState: destinationState)
+                    return processState()
                 }
             default :
                 return possibleTransition

--- a/Tests/TransporterTests/AddingStatesTestCase.swift
+++ b/Tests/TransporterTests/AddingStatesTestCase.swift
@@ -46,4 +46,12 @@ class AddingStatesTestCase: XCTestCase {
         
         XCTAssertNil(state)
     }
+
+    func test_addStates_whenStateExists_doesNotOverridePreviousValue() {
+        let state = State(5)
+        machine.addState(state)
+        XCTAssertEqual(machine.availableStates.filter { $0.value == 5 }.count, 1)
+        machine.addState(State(5))
+        XCTAssertEqual(machine.availableStates.filter { $0.value == 5 }.count, 1)
+    }
 }

--- a/Tests/TransporterTests/EventTests.swift
+++ b/Tests/TransporterTests/EventTests.swift
@@ -95,7 +95,19 @@ class StringTests: XCTestCase {
         machine.fireEvent("Pass")
         XCTAssert(machine.isInState("Passed"))
     }
-    
+
+    func testStateTransitionsWithMultipleEvents() {
+        let event1 = Event(name: "Toggle", sourceValues: ["Initial"], destinationValue: "Passed")
+        let event2 = Event(name: "Toggle", sourceValues: ["Passed"], destinationValue: "Initial")
+        machine.addEvents([event1, event2])
+        XCTAssertTrue(machine.canFireEvent("Toggle"))
+        machine.fireEvent("Toggle")
+        XCTAssert(machine.isInState("Passed"))
+        XCTAssertTrue(machine.canFireEvent("Toggle"))
+        machine.fireEvent("Toggle")
+        XCTAssert(machine.isInState("Initial"))
+    }
+
     func testShouldFireEventBlock() {
         let event = Event(name: "Pass", sourceValues: ["Initial"], destinationValue: "Passed")
         event.shouldFireEvent = { _ in


### PR DESCRIPTION
Summary:
1) Make `StateMachine.availableStates` property publicly available for reading;
2) Consolidate `addState()` operations; add checks so that state names are unique regardless of the way they were added;
3) Eliminate code duplication in `StateMachine._fireEventNamed()` function for cases when the `shouldFireEvent` block was set and when it was not, by extracting the duplicate code into local closure variable;
4) Make it possible for the state machine to find proper transition from state to state, taking into account event's `name` and `sourceValues`.
